### PR TITLE
documentation.tex: Fixed one typo and removed useless package

### DIFF
--- a/documentation/documentation.tex
+++ b/documentation/documentation.tex
@@ -1,6 +1,5 @@
 \documentclass[a4paper,11pt]{article}
 \frenchspacing
-\usepackage{a4wide}
 \usepackage[english]{babel}
 \usepackage[utf8]{inputenc}
 \usepackage{graphicx}
@@ -1421,7 +1420,7 @@ The \cmd{platform} option is used to load the correct high-level device configur
 
 The \cmd{cutter\_type} is used to determine the type of cutter used for the devices. At the time of writing the options are \cmd{clewarecutter} and \cmd{usbrelay}.
 
-The \cmd{test\_plan} option is the name of the name of the test plan configuration file under \cmd{test\_plan} folder.
+The \cmd{test\_plan} option is the name of the test plan configuration file under \cmd{test\_plan} folder.
 
 For \emph{PC-devices}, the additional options are as follows:
 \begin{itemize}


### PR DESCRIPTION
Signed-off-by: Simo Kuusela simo.kuusela@intel.com
