### PR TITLE
main.py: Add possibility to flash specific machine

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ import sys
 import logging
 import argparse
 import aft.config as config
+import aft.errors as errors
 import aft.tools.device_configuration_checker as device_config
 from aft.tools.topology_builder import TopologyBuilder
 from aft.tools.edison_recovery_flasher import recover_edisons
@@ -108,7 +109,10 @@ def main(argv=None):
             print("Both machine and image must be specified")
             return 1
 
-        device = device_manager.reserve()
+        try:
+            device = device_manager.reserve_specific(args.machine)
+        except errors.AFTConfigurationError:
+            device = device_manager.reserve()
         tester = Tester(device)
 
         if args.record:


### PR DESCRIPTION
Change main.py so that it first tries to reserve specific machine and if
it fails it tries reserving with model name. This allows the use of
specific machine name or model name when flashing with aft.

Signed-off-by: Simo Kuusela simo.kuusela@intel.com
