### PR TITLE
main.py: Print "Testing [device]" before tester.execute()

### DIFF
--- a/main.py
+++ b/main.py
@@ -123,6 +123,7 @@ def main(argv=None):
             device.write_image(args.file_name)
 
         if not args.notest:
+            print("Testing " + str(device.name) + ".")
             tester.execute()
 
         if not args.nopoweroff:


### PR DESCRIPTION
Previously if '--noflash' was used aft didn't print anything to console before
testing is finished which looks like aft isn't doing anything.

Signed-off-by: Simo Kuusela simo.kuusela@intel.com
